### PR TITLE
Add NuGet publish job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,3 +126,33 @@ stages:
             env:
               progetApiKey : $(progetApiKey)
             displayName: Publish Package
+
+- stage: NuGet
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  variables:
+  - group: nuget-deployment-vars
+  jobs:
+  - deployment: Publish_To_NuGet
+    displayName: Publish To NuGet
+    pool:
+      name: NautilusRelease
+    environment: UKHO-ADDS-Infrastructure-NuGet
+    workspace:
+      clean: all
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - task: UseDotNet@2
+            displayName: 'Use .NET $(SdkVersion) sdk'
+            inputs:
+              packageType: sdk
+              version: $(SdkVersion)
+
+          - download: current
+            artifact: NuGetPackages
+
+          - powershell: Get-ChildItem "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -File | Foreach {dotnet nuget push $_.fullname -k $(nugetApiKey) -s https://api.nuget.org/v3/index.json --no-symbols true}
+            env:
+              nugetApiKey : $(nugetApiKey)
+            displayName: Publish Package

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,7 +98,7 @@ stages:
         artifact: NuGetPackages
 
 - stage: ProGet
-  #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   variables:
   - group: nuget-deployment-vars
   jobs:
@@ -128,7 +128,7 @@ stages:
             displayName: Publish Package
 
 - stage: NuGet
-  #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   variables:
   - group: nuget-deployment-vars
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,7 +98,7 @@ stages:
         artifact: NuGetPackages
 
 - stage: ProGet
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   variables:
   - group: nuget-deployment-vars
   jobs:
@@ -128,7 +128,7 @@ stages:
             displayName: Publish Package
 
 - stage: NuGet
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   variables:
   - group: nuget-deployment-vars
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,9 +122,9 @@ stages:
           - download: current
             artifact: NuGetPackages
 
-          - powershell: Get-ChildItem "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -File | Foreach {dotnet nuget push $_.fullname -k $(progetApiKey) -s https://progetcloud.ukho.gov.uk/nuget/ukho.trusted/v3/index.json }
+          - powershell: Get-ChildItem "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -File | Foreach {dotnet nuget push $_.fullname -k $(progetapikey) -s https://progetcloud.ukho.gov.uk/nuget/ukho.trusted/v3/index.json }
             env:
-              progetApiKey : $(progetApiKey)
+              progetApiKey : $(progetapikey)
             displayName: Publish Package
 
 - stage: NuGet
@@ -152,7 +152,7 @@ stages:
           - download: current
             artifact: NuGetPackages
 
-          - powershell: Get-ChildItem "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -File | Foreach {dotnet nuget push $_.fullname -k $(nugetApiKey) -s https://api.nuget.org/v3/index.json --no-symbols true}
+          - powershell: Get-ChildItem "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -File | Foreach {dotnet nuget push $_.fullname -k $(nugetapikey) -s https://api.nuget.org/v3/index.json --no-symbols true}
             env:
-              nugetApiKey : $(nugetApiKey)
+              nugetApiKey : $(nugetapikey)
             displayName: Publish Package

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,7 +152,7 @@ stages:
           - download: current
             artifact: NuGetPackages
 
-          - powershell: Get-ChildItem "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -File | Foreach {dotnet nuget push $_.fullname -k $(nugetapikey) -s https://api.nuget.org/v3/index.json --no-symbols true}
+          - powershell: Get-ChildItem "$(Pipeline.Workspace)/NuGetPackages/*.nupkg" -File | Foreach {dotnet nuget push $_.fullname -k $(nugetapikey) -s https://api.nuget.org/v3/index.json --no-symbols}
             env:
               nugetApiKey : $(nugetapikey)
             displayName: Publish Package

--- a/src/UKHO.ADDS.Infrastructure.Pipelines/UKHO.ADDS.Infrastructure.Pipelines.csproj
+++ b/src/UKHO.ADDS.Infrastructure.Pipelines/UKHO.ADDS.Infrastructure.Pipelines.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -9,11 +9,16 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/UKHO/UKHO.ADDS.Infrastructure</PackageProjectUrl>
     <RepositoryUrl>https://github.com/UKHO/UKHO.ADDS.Infrastructure</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.*" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>

--- a/src/UKHO.ADDS.Infrastructure.Results/UKHO.ADDS.Infrastructure.Results.csproj
+++ b/src/UKHO.ADDS.Infrastructure.Results/UKHO.ADDS.Infrastructure.Results.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -10,6 +10,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/UKHO/UKHO.ADDS.Infrastructure</PackageProjectUrl>
     <RepositoryUrl>https://github.com/UKHO/UKHO.ADDS.Infrastructure</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -19,5 +20,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <NoWarn>1701;1702;8632;</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
 
 </Project>

--- a/src/UKHO.ADDS.Infrastructure.Serialization/UKHO.ADDS.Infrastructure.Serialization.csproj
+++ b/src/UKHO.ADDS.Infrastructure.Serialization/UKHO.ADDS.Infrastructure.Serialization.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -10,6 +10,11 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/UKHO/UKHO.ADDS.Infrastructure</PackageProjectUrl>
     <RepositoryUrl>https://github.com/UKHO/UKHO.ADDS.Infrastructure</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
#### PR Classification
Updates to Azure Pipelines configuration and project files for enhanced package management.

#### PR Summary
This pull request modifies the Azure Pipelines configuration to include a new stage for publishing to NuGet and updates project files to improve package metadata. 
- `azure-pipelines.yml`: Changed ProGet API key variable name and added a new stage for NuGet publishing.
- `UKHO.ADDS.Infrastructure.Pipelines.csproj`: Added `PackageReadmeFile` and included README.md in the package.
- `UKHO.ADDS.Infrastructure.Results.csproj`: Added `PackageReadmeFile` and included README.md in the package.
- `UKHO.ADDS.Infrastructure.Serialization.csproj`: Added `PackageReadmeFile` and included README.md in the package.
